### PR TITLE
feat: reassign stuck partition replicas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,6 +260,8 @@ project(':cruise-control') {
     testCompile project(path: ':cruise-control-core', configuration: 'testOutput')
     testCompile "org.scala-lang:scala-library:2.12.10"
     testCompile 'org.easymock:easymock:4.3'
+    testCompile 'org.powermock:powermock-module-junit4:2.0.9'
+    testCompile 'org.powermock:powermock-api-easymock:2.0.9'
     testCompile "org.apache.kafka:kafka_2.12:$kafkaVersion:test"
     testCompile "org.apache.kafka:kafka-clients:$kafkaVersion:test"
     testCompile 'commons-io:commons-io:2.10.0'

--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -97,10 +97,10 @@ capacity.config.file=config/capacity.json
 # =======================================
 
 # The list of goals to optimize the Kafka cluster for with pre-computed proposals
-default.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal
+default.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LaggingReplicaReassignmentGoal
 
 # The list of supported goals
-goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal
+goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LaggingReplicaReassignmentGoal
 #com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal
 #
 
@@ -112,9 +112,9 @@ hard.goals=
 #com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal
 #com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
 
-anomaly.detection.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal
+anomaly.detection.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LaggingReplicaReassignmentGoal
 
-self.healing.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal
+self.healing.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LaggingReplicaReassignmentGoal
 
 # The minimum percentage of well monitored partitions out of all the partitions
 min.valid.partition.ratio=0.95
@@ -380,3 +380,5 @@ two.step.purgatory.retention.time.ms=1209600000
 two.step.purgatory.max.requests=25
 
 remove.stuck.partition.reassignments=false
+
+lagging.replica.reassign.ms=300000

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LaggingReplicaReassignmentGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LaggingReplicaReassignmentGoal.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * adding due to checkstyle 
+ */
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.MonitorConfig;
+import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewPartitionReassignment;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.createAdminClient;
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.parseAdminClientConfigs;
+
+/***
+ * Sometimes, replicas are unable to be updated to in-sync state to zookeeper
+ * This happens during kafka-zk and inter-zk network outages. This leads to a state 
+ * where the paritions are forever stuck in an under-replicated state.
+ * See KAFKA-1407, KAFKA-3042 for more information. This goal aims to fix this 
+ * by detecting replicas in this state and reassigning replicas to the same brokers. 
+ */
+public class LaggingReplicaReassignmentGoal extends AbstractGoal {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LaggingReplicaReassignmentGoal.class);
+    private boolean _laggingRecoveryNeeded;
+
+    private List<PartitionInfo> _laggingPartitions;
+
+    protected ConcurrentHashMap<PartitionInfoWrapper, Long> _laggingPartitionsMap;
+
+    private ConcurrentHashMap<PartitionInfoWrapper, Long> _newLaggingPartitionsMap;
+
+    private long _maxReplicaLagMs;
+
+    private AdminClient _adminClient;
+
+    private KafkaCruiseControlConfig _parsedConfig;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        _parsedConfig = new KafkaCruiseControlConfig(configs, false);
+        _adminClient = createAdminClient(parseAdminClientConfigs(_parsedConfig));
+        _balancingConstraint = new BalancingConstraint(_parsedConfig);
+        _numWindows = _parsedConfig.getInt(MonitorConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG);
+        _minMonitoredPartitionPercentage = _parsedConfig.getDouble(MonitorConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
+        _laggingPartitionsMap = new ConcurrentHashMap<PartitionInfoWrapper, Long>();
+        _maxReplicaLagMs = (long) configs.get(AnalyzerConfig.MAX_LAGGING_REPLICA_REASSIGN_MS);
+        _laggingPartitions = new ArrayList<PartitionInfo>();
+        _laggingRecoveryNeeded = false;
+    }
+
+    @Override
+    public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
+        switch (action.balancingAction()) {
+            case INTER_BROKER_REPLICA_MOVEMENT:
+                return ActionAcceptance.ACCEPT;
+            default:
+              return ActionAcceptance.ACCEPT;
+        }
+    }
+
+    @Override
+    public ClusterModelStatsComparator clusterModelStatsComparator() {
+        return new ClusterModelStatsComparator() {
+
+            private StringBuffer _reason = new StringBuffer();
+
+            @Override
+            public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+                int s1 = stats1.numPartitionsWithLaggingReplicas();
+                int s2 = stats2.numPartitionsWithLaggingReplicas();
+                _reason.setLength(0);
+                if (s1 > s2) {
+                    _reason.append("Number of partitions with lagging replicas increased from " + s2 + " to " + s1);
+                    return -1;
+                } else {
+                    _reason.append("Number of partitions with lagging replicas decreased from " + s2 + " to " + s1);
+                    return 0;
+                }
+            }
+
+            @Override
+            public String explainLastComparison() {
+                return _reason.toString();
+            }
+
+        };
+    }
+
+    @Override
+    public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
+        return new ModelCompletenessRequirements(GoalUtils.MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING, 0.0, true);
+    }
+
+    @Override
+    public boolean isHardGoal() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return LaggingReplicaReassignmentGoal.class.getSimpleName();
+    }
+
+    @Override
+    protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
+        return false;
+    }
+
+    @Override
+    protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+            throws OptimizationFailureException {
+        LOG.info("initGoalState");
+        checkIfReplicasLagging(clusterModel);
+    }
+
+    @Override
+    protected void updateGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+            throws OptimizationFailureException {
+        
+        LOG.info("updateGoalState");
+        checkIfReplicasLagging(clusterModel);
+        if (!_laggingRecoveryNeeded) {
+            finish();
+        }
+
+    }
+
+    void checkIfReplicasLagging(ClusterModel clusterModel) throws OptimizationFailureException {
+        long currentTimeMillis = System.currentTimeMillis();
+        _newLaggingPartitionsMap = new ConcurrentHashMap<PartitionInfoWrapper, Long>();
+        LOG.info("Checking for lagging replicas");
+        if (_laggingPartitionsMap == null) {
+            _laggingPartitionsMap = new ConcurrentHashMap<PartitionInfoWrapper, Long>();
+        }
+        //List<PartitionInfo> laggingPartitionInfos = clusterModel.getPartitionsWithLaggingReplicas();
+        //_laggingPartitionsMap.entrySet().removeIf(e -> !laggingPartitionInfos.contains(e.getKey()._pi));
+        for (PartitionInfo partition: clusterModel.getPartitionsWithLaggingReplicas()) {
+            LOG.info(partition.toString());
+            PartitionInfoWrapper piw = new PartitionInfoWrapper(partition);
+            long lastSeenTime = _laggingPartitionsMap.getOrDefault(piw, currentTimeMillis);
+            if (currentTimeMillis - lastSeenTime >= _maxReplicaLagMs) {
+                LOG.info("Partition {} has been lagging for past {} minutes", partition.toString(), 
+                            (currentTimeMillis - lastSeenTime) / (60 * 1000));
+                _laggingRecoveryNeeded = true;
+                _laggingPartitions.add(partition);
+            }
+            _newLaggingPartitionsMap.put(piw, lastSeenTime);
+        }
+        _laggingPartitionsMap = _newLaggingPartitionsMap;
+        LOG.info("Lagging partitions map: {}  on thread after {}", _laggingPartitionsMap.toString(), Thread.currentThread().getName());
+    }
+
+    List<PartitionInfo> getLaggingPartitions() {
+        return _laggingPartitions;
+    }
+
+    @Override
+    protected void rebalanceForBroker(Broker broker, ClusterModel clusterModel, Set<Goal> optimizedGoals,
+            OptimizationOptions optimizationOptions) throws OptimizationFailureException {
+        
+        LOG.info("Current lagging partitions: {} ", _laggingPartitions.toString());
+        if (_laggingRecoveryNeeded) {
+            Map<TopicPartition, Optional<NewPartitionReassignment>> reassignments = new HashMap<>(); 
+            // gather all the lagging partitions into a reassignments map
+            for (PartitionInfo laggingPartition: _laggingPartitions) {
+                List<Node> laggingReplicas = new LinkedList<Node>(Arrays.asList(laggingPartition.replicas()));
+                reassignments.put(new TopicPartition(laggingPartition.topic(), laggingPartition.partition()), 
+                Optional.of(new NewPartitionReassignment(laggingReplicas.stream().map(node -> node.id()).collect(Collectors.toList()))));
+                _laggingPartitionsMap.remove(new PartitionInfoWrapper(laggingPartition));
+            }
+            // use admin client to move them to same brokers
+            try {
+                _adminClient.alterPartitionReassignments(reassignments).all().get();
+                reassignments.entrySet().stream().forEach(e -> LOG.info("Moved partition {}: {}", e.getKey(), e.getValue().get().targetReplicas()));
+                _laggingPartitions.clear();
+                _laggingRecoveryNeeded = false;
+            } catch (InterruptedException | ExecutionException e) {
+                LOG.error("Unable to move replicas onto same brokers");
+            }
+        }
+        
+    }
+    protected static class PartitionInfoWrapper {
+
+        PartitionInfo _pi;
+
+        public PartitionInfoWrapper(PartitionInfo pi) {
+            this._pi = pi;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (!(o instanceof PartitionInfoWrapper)) {
+                return false;
+            }
+            PartitionInfoWrapper partitionInfoWrapperObj = (PartitionInfoWrapper) o;
+            PartitionInfo p2 = partitionInfoWrapperObj._pi;
+            if (_pi.topic().equals(p2.topic()) && _pi.partition() == p2.partition() 
+                && _pi.leader().id() == p2.leader().id() && _pi.inSyncReplicas().length == p2.inSyncReplicas().length) {
+                Set<Integer> p2ISRSet = Arrays.stream(p2.inSyncReplicas()).map(isr -> isr.id()).collect(Collectors.toSet());
+                if (Arrays.stream(_pi.inSyncReplicas()).allMatch(isr -> p2ISRSet.contains(isr.id()))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((_pi.topic() == null) ? 0 : _pi.topic().hashCode());
+            result = prime * result + _pi.partition();
+            result = prime * result + _pi.leader().id();
+            for (Node n: _pi.inSyncReplicas()) {
+                result = prime * result + n.id();
+            }
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return _pi.toString();
+        }
+
+    }
+    
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/AnalyzerConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/AnalyzerConfig.java
@@ -230,6 +230,14 @@ public class AnalyzerConfig {
       + "optimization proposal candidates. The more threads are used, the more memory and CPU resource will be used.";
 
   /**
+   * <code>num.proposal.precompute.threads</code>
+   */
+  public static final String MAX_LAGGING_REPLICA_REASSIGN_MS = "lagging.replica.reassign.ms";
+  public static final long DEFAULT_MAX_LAGGING_REPLICA_REASSIGN_MS = 30 * 60 * 1000L;
+  public static final String DEFAULT_MAX_LAGGING_REPLICA_REASSIGN_DOC = "How long to wait before manually reassigning "
+      + "lagging partitions. Defaults to 30 minutes";
+
+  /**
    * <code>optimization.options.generator.class</code>
    */
   public static final String OPTIMIZATION_OPTIONS_GENERATOR_CLASS_CONFIG = "optimization.options.generator.class";
@@ -636,6 +644,11 @@ public class AnalyzerConfig {
                             DEFAULT_FAST_MODE_PER_BROKER_MOVE_TIMEOUT_MS,
                             atLeast(1),
                             ConfigDef.Importance.LOW,
-                            FAST_MODE_PER_BROKER_MOVE_TIMEOUT_MS_DOC);
+                            FAST_MODE_PER_BROKER_MOVE_TIMEOUT_MS_DOC)
+                    .define(MAX_LAGGING_REPLICA_REASSIGN_MS,
+                            ConfigDef.Type.LONG,
+                            DEFAULT_MAX_LAGGING_REPLICA_REASSIGN_MS,
+                            ConfigDef.Importance.LOW,
+                            DEFAULT_MAX_LAGGING_REPLICA_REASSIGN_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -72,6 +72,11 @@ public class ClusterModel implements Serializable {
   private final Map<Integer, Load> _potentialLeadershipLoadByBrokerId;
   private int _unknownHostId;
   private final Map<Integer, String> _capacityEstimationInfoByBrokerId;
+  private final Cluster _cluster;
+
+  public ClusterModel(ModelGeneration generation, double monitoredPartitionsRatio) {
+    this(generation, monitoredPartitionsRatio, null);
+  }
 
   /**
    * Constructor for the cluster class. It creates data structures to hold a list of racks, a map for partitions by
@@ -80,7 +85,7 @@ public class ClusterModel implements Serializable {
    * @param generation Model generation of the cluster
    * @param monitoredPartitionsRatio Monitored partitions ratio
    */
-  public ClusterModel(ModelGeneration generation, double monitoredPartitionsRatio) {
+  public ClusterModel(ModelGeneration generation, double monitoredPartitionsRatio, Cluster cluster) {
     _generation = generation;
     _racksById = new HashMap<>();
     _brokerIdToRack = new HashMap<>();
@@ -108,6 +113,21 @@ public class ClusterModel implements Serializable {
     _monitoredPartitionsRatio = monitoredPartitionsRatio;
     _unknownHostId = 0;
     _capacityEstimationInfoByBrokerId = new HashMap<>();
+    _cluster = cluster;
+  }
+
+  /**
+   * @return The partitions which have lagging replicas without any offline partitions. 
+   * This would imply that the ReplicaFetcher is either unable to catch up or has stopped fetching for some reason.
+   */
+  public List<PartitionInfo> getPartitionsWithLaggingReplicas() {
+    if (_cluster == null) {
+      return new ArrayList<PartitionInfo>();
+    }
+    return _cluster.topics().stream().filter(topic -> !topic.startsWith("__"))
+            .map(topic -> _cluster.partitionsForTopic(topic)).flatMap(List::stream)
+            .filter(partition -> (partition.replicas().length != partition.inSyncReplicas().length && partition.offlineReplicas().length == 0))
+            .collect(Collectors.toList());
   }
 
   /**
@@ -858,7 +878,7 @@ public class ClusterModel implements Serializable {
         }
       }
       replica = new Replica(tp, broker, isLeader, isOffline, disk);
-    } else {
+    } else { 
       replica = new Replica(tp, GENESIS_BROKER, false);
       replica.setBroker(broker);
     }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModelStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModelStats.java
@@ -40,6 +40,7 @@ public class ClusterModelStats {
   private int _numBrokers;
   private int _numReplicasInCluster;
   private int _numPartitionsWithOfflineReplicas;
+  private int _numPartitionsWithLaggingReplicas;
   private int _numTopics;
   private final Map<Resource, Integer> _numBalancedBrokersByResource;
   private int _numBrokersUnderPotentialNwOut;
@@ -65,6 +66,7 @@ public class ClusterModelStats {
     _numBrokers = 0;
     _numReplicasInCluster = 0;
     _numPartitionsWithOfflineReplicas = 0;
+    _numPartitionsWithLaggingReplicas = 0;
     _numTopics = 0;
     _numBrokersUnderPotentialNwOut = 0;
     _numBalancedBrokersByResource = new HashMap<>();
@@ -98,7 +100,12 @@ public class ClusterModelStats {
     _numSnapshotWindows = clusterModel.load().numWindows();
     _monitoredPartitionsRatio = clusterModel.monitoredPartitionsRatio();
     populateStatsForDisks(balancingConstraint, aliveBrokers);
+    populateLaggingPartitionReplicasCount(clusterModel);
     return this;
+  }
+
+  private void populateLaggingPartitionReplicasCount(ClusterModel clusterModel) {
+    _numPartitionsWithLaggingReplicas = clusterModel.getPartitionsWithLaggingReplicas().size();
   }
 
   /**
@@ -106,6 +113,13 @@ public class ClusterModelStats {
    */
   public Map<Statistic, Map<Resource, Double>> resourceUtilizationStats() {
     return _resourceUtilizationStats;
+  }
+
+  /**
+   * @return The number of partitions with lagging replicas(i.e, not in ISR set)
+   */
+  public int numPartitionsWithLaggingReplicas() {
+    return _numPartitionsWithLaggingReplicas;
   }
 
   /**
@@ -382,6 +396,7 @@ public class ClusterModelStats {
       partitionsWithOfflineReplicas.add(replica.topicPartition());
     }
     _numPartitionsWithOfflineReplicas = partitionsWithOfflineReplicas.size();
+    
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/LoadMonitor.java
@@ -471,7 +471,7 @@ public class LoadMonitor {
 
     // Create an empty cluster model first.
     ModelGeneration modelGeneration = new ModelGeneration(clusterAndGeneration.generation(), -1L);
-    ClusterModel clusterModel = new ClusterModel(modelGeneration, 0.0);
+    ClusterModel clusterModel = new ClusterModel(modelGeneration, 0.0, cluster);
 
     populateClusterCapacity(false, false, clusterModel, cluster);
     // Set the state of bad brokers in clusterModel based on the Kafka cluster state.
@@ -559,7 +559,7 @@ public class LoadMonitor {
     long currentLoadGeneration = partitionMetricSampleAggregationResult.generation();
     ModelGeneration modelGeneration = new ModelGeneration(clusterAndGeneration.generation(), currentLoadGeneration);
     MetricSampleCompleteness<String, PartitionEntity> completeness = partitionMetricSampleAggregationResult.completeness();
-    ClusterModel clusterModel = new ClusterModel(modelGeneration, completeness.validEntityRatio());
+    ClusterModel clusterModel = new ClusterModel(modelGeneration, completeness.validEntityRatio(), cluster);
 
     final Timer.Context ctx = _clusterModelCreationTimer.time();
     try {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LaggingReplicaReassignmentGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LaggingReplicaReassignmentGoalTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * adding due to checkstyle 
+ */
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.Goal.ClusterModelStatsComparator;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.LaggingReplicaReassignmentGoal.PartitionInfoWrapper;
+import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterPartitionReassignmentsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.easymock.EasyMock;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties;
+import static com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig.MAX_LAGGING_REPLICA_REASSIGN_MS;
+import static com.linkedin.kafka.cruisecontrol.model.SortedReplicasTest.generateBroker;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(KafkaCruiseControlUtils.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class LaggingReplicaReassignmentGoalTest {
+    
+    /**
+     * @throws Exception 
+     * 
+    */
+    @Test
+    public void checkifLaggingPartitionReplicaMoved() throws Exception {
+        LaggingReplicaReassignmentGoal goal = new LaggingReplicaReassignmentGoal();
+        Map props = getKafkaCruiseControlProperties();
+        Map<String, Object> configs = (Map<String, Object>) props;
+        configs.put(MAX_LAGGING_REPLICA_REASSIGN_MS, 1000L);
+        System.out.println(configs);
+        
+        //mock admin client
+        AdminClient adminClient = EasyMock.createMock(AdminClient.class);
+        PowerMock.mockStatic(KafkaCruiseControlUtils.class);
+        EasyMock.expect(KafkaCruiseControlUtils.createAdminClient(EasyMock.anyObject())).andReturn(adminClient);
+        EasyMock.expect(KafkaCruiseControlUtils.parseAdminClientConfigs(EasyMock.anyObject())).andReturn(configs);
+        PowerMock.replay(KafkaCruiseControlUtils.class);
+        
+        //mock alterPartitionReassignment which should happen only once
+        AlterPartitionReassignmentsResult aprResult = EasyMock.createMock(AlterPartitionReassignmentsResult.class);
+        EasyMock.expect(aprResult.all()).andReturn(KafkaFuture.completedFuture(null)).times(1);
+
+        goal.configure(configs);
+        Set<Goal> optimizedGoals = new HashSet<Goal>();
+        optimizedGoals.add(goal);
+        assertEquals(goal.name(), LaggingReplicaReassignmentGoal.class.getSimpleName());
+
+        ClusterModel clusterModel = EasyMock.createMock(ClusterModel.class);
+        ClusterModelStats clusterModelStats = EasyMock.createMock(ClusterModelStats.class);
+        ClusterModelStatsComparator clusterModelStatsComparator = EasyMock.createMock(ClusterModelStatsComparator.class);
+
+        Node node1 = new Node(0, "node1", 9092);
+        Node node2 = new Node(1, "node2", 9092);
+        Node node3 = new Node(2, "node3", 9092);
+        Node[] replicas = {node1, node2, node3};
+        Node[] isr = {node1, node2};
+        PartitionInfo partitionInfo1 = new PartitionInfo("topic1", 0, node1, replicas, isr);
+        PartitionInfo partitionInfo2 = new PartitionInfo("topic2", 0, node1, replicas, isr);
+        PartitionInfo partitionInfo2Copy = new PartitionInfo("topic2", 0, node1, replicas, isr);
+        List<PartitionInfo> partitionsWithLaggingReplicas1 = new ArrayList<PartitionInfo>();
+        partitionsWithLaggingReplicas1.add(partitionInfo1);
+        List<PartitionInfo> partitionsWithLaggingReplicas2 = new ArrayList<PartitionInfo>();
+        partitionsWithLaggingReplicas2.add(partitionInfo2);
+        List<PartitionInfo> partitionsWithLaggingReplicas12 = new ArrayList<PartitionInfo>(partitionsWithLaggingReplicas1);
+        partitionsWithLaggingReplicas12.add(partitionInfo2);
+        // send 1 partition w/ lagging replica
+        EasyMock.expect(clusterModelStats.numPartitionsWithLaggingReplicas()).andReturn(1).times(6);
+        EasyMock.expect(clusterModel.getClusterStats(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(clusterModelStats).anyTimes();
+        EasyMock.expect(clusterModelStatsComparator.compare(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(0);
+
+        EasyMock.expectLastCall().andAnswer(() -> {
+            return null;
+        }).anyTimes();
+        clusterModel.clearSortedReplicas();
+        clusterModel.clearSortedReplicas();
+        EasyMock.expect(clusterModel.getPartitionsWithLaggingReplicas()).andReturn(new ArrayList<PartitionInfo>());
+        EasyMock.expect(clusterModel.getPartitionsWithLaggingReplicas()).andReturn(partitionsWithLaggingReplicas1);
+        EasyMock.expect(clusterModel.getPartitionsWithLaggingReplicas()).andReturn(partitionsWithLaggingReplicas12);
+        EasyMock.expect(clusterModel.getPartitionsWithLaggingReplicas()).andReturn(partitionsWithLaggingReplicas2);
+        EasyMock.expect(clusterModel.brokenBrokers()).andReturn(new TreeSet<Broker>()).anyTimes();
+        EasyMock.expect(clusterModel.brokers()).andReturn(new TreeSet<Broker>(Arrays.asList(replicas).stream()
+                        .map(node -> generateBroker(node.id(), 0)).collect(Collectors.toList()))).anyTimes();
+        EasyMock.expect(clusterModel.aliveBrokers()).andReturn(new TreeSet<Broker>()).anyTimes();
+        EasyMock.expect(adminClient.alterPartitionReassignments(EasyMock.anyObject())).andReturn(aprResult);
+        EasyMock.replay(clusterModel, clusterModelStats, clusterModelStatsComparator, adminClient, aprResult);
+        // optimize once before sleep 
+        goal.optimize(clusterModel, optimizedGoals, new OptimizationOptions(new HashSet<String>(), new HashSet<Integer>(), new HashSet<Integer>()));
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // optimize again after sleep
+        goal.optimize(clusterModel, optimizedGoals, new OptimizationOptions(new HashSet<String>(), new HashSet<Integer>(), new HashSet<Integer>()));
+        // should have been moved as 1st seen before sleep
+        assertFalse(goal._laggingPartitionsMap.containsKey(new PartitionInfoWrapper(partitionInfo1)));
+        // still hasnt reached maxLagTimeMS threshold
+        assertTrue(goal._laggingPartitionsMap.containsKey(new PartitionInfoWrapper(partitionInfo2Copy)));
+        EasyMock.verify(clusterModel);
+    }
+
+    /** 
+     * Start with both tp's lagging, then both have all in-sync, then they start lagging again.
+     * In this case, they should be absent (from target replicas to be moved) 
+     * post 2nd-optimize and present post 3rd-optimize
+    */
+    @Test
+    public void checkNonLaggingPartitionNotMoved() throws OptimizationFailureException {
+        LaggingReplicaReassignmentGoal goal = new LaggingReplicaReassignmentGoal();
+        Map props = getKafkaCruiseControlProperties();
+        Map<String, Object> configs = (Map<String, Object>) props;
+        configs.put(MAX_LAGGING_REPLICA_REASSIGN_MS, 1000L);
+
+        //mock admin client
+        AdminClient adminClient = EasyMock.createMock(AdminClient.class);
+        PowerMock.mockStatic(KafkaCruiseControlUtils.class);
+        EasyMock.expect(KafkaCruiseControlUtils.createAdminClient(EasyMock.anyObject())).andReturn(adminClient);
+        EasyMock.expect(KafkaCruiseControlUtils.parseAdminClientConfigs(EasyMock.anyObject())).andReturn(configs);
+        PowerMock.replay(KafkaCruiseControlUtils.class);
+
+        goal.configure(configs);
+        Set<Goal> optimizedGoals = new HashSet<Goal>();
+        optimizedGoals.add(goal);
+
+        ClusterModel clusterModel = EasyMock.createMock(ClusterModel.class);
+        ClusterModelStats clusterModelStats = EasyMock.createMock(ClusterModelStats.class);
+        ClusterModelStatsComparator clusterModelStatsComparator = EasyMock.createMock(ClusterModelStatsComparator.class);
+
+        Node node1 = new Node(0, "node1", 9092);
+        Node node2 = new Node(1, "node2", 9092);
+        Node node3 = new Node(2, "node3", 9092);
+        Node[] replicas = {node1, node2, node3};
+        Node[] isr = {node1, node2};
+        PartitionInfo partitionInfo1 = new PartitionInfo("topic1", 0, node1, replicas, isr);
+        PartitionInfo partitionInfo2 = new PartitionInfo("topic2", 0, node1, replicas, isr);
+        PartitionInfo partitionInfo2Copy = new PartitionInfo("topic2", 0, node1, replicas, isr);
+        List<PartitionInfo> partitionsWithLaggingReplicas12 = new ArrayList<PartitionInfo>();
+        partitionsWithLaggingReplicas12.add(partitionInfo1);
+        partitionsWithLaggingReplicas12.add(partitionInfo2);
+        // send 1 partition w/ lagging replica
+        EasyMock.expect(clusterModelStats.numPartitionsWithLaggingReplicas()).andReturn(1).times(9);
+        EasyMock.expect(clusterModel.getClusterStats(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(clusterModelStats).anyTimes();
+        EasyMock.expect(clusterModelStatsComparator.compare(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(0);
+
+        EasyMock.expectLastCall().andAnswer(() -> {
+            return null;
+        }).anyTimes();
+        clusterModel.clearSortedReplicas();
+        clusterModel.clearSortedReplicas();
+        clusterModel.clearSortedReplicas();
+        EasyMock.expect(clusterModel.getPartitionsWithLaggingReplicas()).andReturn(partitionsWithLaggingReplicas12).times(2);
+        EasyMock.expect(clusterModel.getPartitionsWithLaggingReplicas()).andReturn(new ArrayList<PartitionInfo>()).times(2);
+        EasyMock.expect(clusterModel.getPartitionsWithLaggingReplicas()).andReturn(partitionsWithLaggingReplicas12).times(2);
+        EasyMock.expect(clusterModel.brokenBrokers()).andReturn(new TreeSet<Broker>()).anyTimes();
+        EasyMock.expect(clusterModel.brokers()).andReturn(new TreeSet<Broker>(Arrays.asList(replicas).stream()
+                        .map(node -> generateBroker(node.id(), 0)).collect(Collectors.toList()))).anyTimes();
+        EasyMock.expect(clusterModel.aliveBrokers()).andReturn(new TreeSet<Broker>()).anyTimes();
+        EasyMock.replay(clusterModel, clusterModelStats, clusterModelStatsComparator);
+        // optimize once before sleep 
+        goal.optimize(clusterModel, optimizedGoals, new OptimizationOptions(new HashSet<String>(), new HashSet<Integer>(), new HashSet<Integer>()));
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // optimize again after sleep
+        goal.optimize(clusterModel, optimizedGoals, new OptimizationOptions(new HashSet<String>(), new HashSet<Integer>(), new HashSet<Integer>()));
+        assertFalse(goal._laggingPartitionsMap.containsKey(new PartitionInfoWrapper(partitionInfo1)));
+        assertFalse(goal._laggingPartitionsMap.containsKey(new PartitionInfoWrapper(partitionInfo2)));
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // optimize again after sleep
+        goal.optimize(clusterModel, optimizedGoals, new OptimizationOptions(new HashSet<String>(), new HashSet<Integer>(), new HashSet<Integer>()));
+        assertTrue(goal._laggingPartitionsMap.containsKey(new PartitionInfoWrapper(partitionInfo1)));
+        assertTrue(goal._laggingPartitionsMap.containsKey(new PartitionInfoWrapper(partitionInfo2Copy)));
+        EasyMock.verify(clusterModel);
+    }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/model/SortedReplicasTest.java
@@ -156,4 +156,22 @@ public class SortedReplicasTest {
     }
     return broker;
   }
+
+  /**
+   * Generate brokers for use in other tests
+   * @param nodeid Broker id
+   * @param numReplicas # of replicas on broker
+   * @return new {@link com.linkedin.kafka.cruisecontrol.model.Broker}
+   */
+  public static Broker generateBroker(int nodeid, int numReplicas) {
+    Rack rack = new Rack("rack");
+    Host host = new Host("host", rack);
+    Broker broker = new Broker(host, nodeid, new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY), false);
+
+    for (int i = 0; i < numReplicas; i++) {
+      Replica r = new Replica(new TopicPartition(TOPIC0, i), broker, i % 3 == 0);
+      broker.addReplica(r);
+    }
+    return broker;
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
+org.gradle.workers.max=8
 kafkaVersion=2.7.0
 zookeeperVersion=3.5.8
 nettyVersion=4.1.63.Final


### PR DESCRIPTION
Sometimes replicas stop fetching/updating state to ZK without any reason- so far we have seen it happen on rolling restarts but as the source of this bug is as yet unknown, there could be other scenarios as well

This is problematic as the replica will be out of ISR until we manually reassign the partition to a broker(even same one)

Adding a new LaggingReplicaReassignmentGoal that will track such replicas and reassign them to same brokers once the MAX_LAGGING_REPLICA_REASSIGN_MS(default 30 mins) is reached

See also: https://lists.apache.org/thread.html/rbfe9557a4dd8604cffce369e76cc74f90ff8f717f934e6e8b5141053%40%3Cusers.kafka.apache.org%3E

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR>.
