### PR TITLE
fix/cruisecontrol: add partition movement timeout to executor

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/KafkaCruiseControl.java
@@ -276,7 +276,7 @@ public class KafkaCruiseControl {
       if (!partitionsBeingReassigned.isEmpty()) {
         if (_config.getBoolean(ExecutorConfig.DELETE_STALE_PARTITIONS_REASSIGNMENTS)) {
           LOG.info("Trying to resolve stuck partitions {}", partitionsBeingReassigned);
-          _executor.cancelStaleReassignments();
+          _executor.cancelStaleReassignments(partitionsBeingReassigned);
         } else if (_config.getBoolean(ExecutorConfig.REMOVE_STUCK_PARTITIONS_REASSIGNMENTS)) {
           LOG.info("Trying to resolve stuck partitions {}", partitionsBeingReassigned);
           _executor.fixStuckPartitionReassignments();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -142,6 +142,14 @@ public class ExecutorConfig {
       + "A leader movement will be marked as failed if it takes longer than this time to finish.";
 
   /**
+   * <code>partition.reassignment.timeout.ms</code>
+   */
+  public static final String PARTITION_REASSIGNMENT_TIMEOUT_MS_CONFIG = "partition.reassignment.timeout.ms";
+  public static final long DEFAULT_PARTITION_REASSIGNMENT_TIMEOUT_MS_CONFIG = TimeUnit.MINUTES.toMillis(60);
+  public static final String PARTITION_REASSIGNMENT_TIMEOUT_MS_CONFIG_DOC = "The maximum time to wait for a partition reassignment to finish. "
+      + "The reassignment will be marked as failed if it takes longer than this to finish.";
+
+  /**
    * <code>task.execution.alerting.threshold.ms</code>
    */
   public static final String TASK_EXECUTION_ALERTING_THRESHOLD_MS_CONFIG = "task.execution.alerting.threshold.ms";
@@ -533,6 +541,11 @@ public class ExecutorConfig {
                             DEFAULT_LEADER_MOVEMENT_TIMEOUT_MS,
                             ConfigDef.Importance.LOW,
                             LEADER_MOVEMENT_TIMEOUT_MS_DOC)
+                    .define(PARTITION_REASSIGNMENT_TIMEOUT_MS_CONFIG,
+                            ConfigDef.Type.LONG,
+                            DEFAULT_PARTITION_REASSIGNMENT_TIMEOUT_MS_CONFIG,
+                            ConfigDef.Importance.LOW,
+                            PARTITION_REASSIGNMENT_TIMEOUT_MS_CONFIG_DOC)
                     .define(TASK_EXECUTION_ALERTING_THRESHOLD_MS_CONFIG,
                             ConfigDef.Type.LONG,
                             DEFAULT_TASK_EXECUTION_ALERTING_THRESHOLD_MS,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -95,6 +95,7 @@ public class Executor {
   private final KafkaZkClient _kafkaZkClient;
   private final AdminClient _adminClient;
   private final double _leaderMovementTimeoutMs;
+  private final double _partitionReassignmentTimeoutMs;
 
   private static final int NO_STOP_EXECUTION = 0;
   private static final int STOP_EXECUTION = 1;
@@ -191,6 +192,7 @@ public class Executor {
                                                                   time);
     _defaultExecutionProgressCheckIntervalMs = config.getLong(ExecutorConfig.EXECUTION_PROGRESS_CHECK_INTERVAL_MS_CONFIG);
     _leaderMovementTimeoutMs = config.getLong(ExecutorConfig.LEADER_MOVEMENT_TIMEOUT_MS_CONFIG);
+    _partitionReassignmentTimeoutMs = config.getLong(ExecutorConfig.PARTITION_REASSIGNMENT_TIMEOUT_MS_CONFIG);
     _requestedExecutionProgressCheckIntervalMs = null;
     _proposalExecutor =
         Executors.newSingleThreadExecutor(new KafkaCruiseControlThreadFactory("ProposalExecutor", false, LOG));
@@ -834,8 +836,6 @@ public class Executor {
     }
     // Note that in case there is an ongoing partition reassignment, we do not unpause metric sampling.
     if (hasOngoingPartitionReassignments) {
-      // check for stuck partition movements
-      fixStuckPartitionReassignments();
       throw new OngoingExecutionException("There are ongoing inter-broker partition movements.");
     } else {
       boolean hasOngoingIntraBrokerReplicaMovement;
@@ -862,19 +862,9 @@ public class Executor {
    * Required for cases where CC dies while an execution is in progress 
    * Eg. node running CC goes down 
    */
-  public void cancelStaleReassignments() {
+  public void cancelStaleReassignments(Set<TopicPartition> partitionsBeingReassigned) {
     if (!_stuckPartitionsBeingReassinedSemaphore.tryAcquire()) {
       throw new IllegalStateException(String.format("Stuck/Stale partitions currently being reassigned"));
-    }
-    Set<TopicPartition> partitionsBeingReassigned;
-    try {
-      partitionsBeingReassigned = ExecutionUtils.partitionsBeingReassigned(_adminClient);
-    } catch (TimeoutException | InterruptedException | ExecutionException e) {
-      throw new IllegalStateException("Unable to retrieve current partition reassignments", e);
-    }
-    if (partitionsBeingReassigned.isEmpty()) {
-      LOG.info("No stale reassignments found");
-      return;
     }
     Map<TopicPartition, Optional<NewPartitionReassignment>> newReassignments = new HashMap<>();
     for (TopicPartition tp : partitionsBeingReassigned) {
@@ -882,7 +872,7 @@ public class Executor {
     }
     try {
       _adminClient.alterPartitionReassignments(newReassignments).all().get();
-      LOG.info("Cancelled stale partition assignments {}", partitionsBeingReassigned.toString());
+      LOG.info("Cancelled stale partition reassignments {}", partitionsBeingReassigned.toString());
     } catch (InterruptedException | ExecutionException e) {
       LOG.error("Error cancelling ongoing partition reassignments {}", e);
     } finally {
@@ -1895,6 +1885,11 @@ public class Executor {
             break;
 
           case INTER_BROKER_REPLICA_ACTION:
+            if (_time.milliseconds() > task.startTimeMs() + _partitionReassignmentTimeoutMs) {
+              _executionTaskManager.markTaskDead(task);
+              LOG.warn("Killing execution for task {} as it has exceeded maximum partition movement timeout", task);
+              return true;
+            }
             for (ReplicaPlacementInfo broker : task.proposal().newReplicas()) {
               if (cluster.nodeById(broker.brokerId()) == null
                   || deadInterBrokerReassignments.contains(task.proposal().topicPartition())) {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LaggingReplicaReassignmentGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/LaggingReplicaReassignmentGoalTest.java
@@ -61,6 +61,8 @@ public class LaggingReplicaReassignmentGoalTest {
         AdminClient adminClient = EasyMock.createMock(AdminClient.class);
         PowerMock.mockStatic(KafkaCruiseControlUtils.class);
         EasyMock.expect(KafkaCruiseControlUtils.createAdminClient(EasyMock.anyObject())).andReturn(adminClient);
+        KafkaCruiseControlUtils.closeAdminClientWithTimeout(EasyMock.anyObject());
+        EasyMock.expectLastCall();
         EasyMock.expect(KafkaCruiseControlUtils.parseAdminClientConfigs(EasyMock.anyObject())).andReturn(configs);
         PowerMock.replay(KafkaCruiseControlUtils.class);
         


### PR DESCRIPTION
There is an edge case wherein after the partition reassignment was submitted to kafka and before it finished, there was a partition leadership re-election- this causes the reassignment to stall until there is another re-election. However, we do see cases where there is no re-election triggered leading to a partition reassignment being in IN_PROGRESS indefinitely and potentially missing new anomalies due to executor state being in INTER_BROKER_REPLICA_ACTION

By adding a max timeout, we avoid this state by cancelling such reassignments and retrying them later

includes minor cleanup

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR>.
