### PR TITLE
Upgrade io.vertx to 4.4.3 due to CVE-2023-24815 (#2023)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ project(':cruise-control-core') {
     api "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
-    api 'io.vertx:vertx-core:4.2.2'
-    api 'io.vertx:vertx-web:4.2.2'
+    api "io.vertx:vertx-core:${vertxVersion}"
+    api "io.vertx:vertx-web:${vertxVersion}"
 
     testImplementation 'junit:junit:4.13.2'
 
@@ -293,10 +293,10 @@ project(':cruise-control') {
     implementation 'uk.org.webcompere:system-stubs-junit4:1.1.0'
     // Temporary pin for vulnerability
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
-    api 'io.vertx:vertx-web-openapi:4.2.2'
-    api 'io.vertx:vertx-core:4.2.2'
-    api 'io.vertx:vertx-web:4.2.2'
-    api 'io.vertx:vertx-junit5:4.2.2'
+    api "io.vertx:vertx-web-openapi:${vertxVersion}"
+    api "io.vertx:vertx-core:${vertxVersion}"
+    api "io.vertx:vertx-web:${vertxVersion}"
+    api "io.vertx:vertx-junit5:${vertxVersion}"
     api 'io.swagger.core.v3:swagger-annotations:2.0.2'
     api 'io.swagger.core.v3:swagger-core:2.0.2'
     api 'com.google.guava:guava:25.1-jre'

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ kafkaVersion=3.1.0
 zookeeperVersion=3.6.3
 nettyVersion=4.1.89.Final
 jettyVersion=9.4.47.v20220610
+vertxVersion=4.4.3


### PR DESCRIPTION
This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR>.


